### PR TITLE
Integrate Sentry.io with existing back end logging

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -42,59 +42,52 @@ class Game(object):
         self._game_id = game_id
 
     def play(self, tribe1: Tribe, tribe2: Tribe, gamedb: Database, engine: Engine) -> Player:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
-
         last_tribe_standing = self._play_multi_tribe(tribe1=tribe1, tribe2=tribe2,
                                                      gamedb=gamedb, engine=engine)
-        log_message("Last tribe standing is {}.".format(last_tribe_standing), game_id)
+        log_message(message="Last tribe standing is {}.".format(last_tribe_standing), game_id=self._game_id)
         last_team_standing = self._play_single_tribe(
             tribe=last_tribe_standing, gamedb=gamedb, engine=engine)
 
-        log_message("Last team standing is {}.".format(last_team_standing), game_id)
+        log_message(message="Last team standing is {}.".format(last_team_standing), game_id=self._game_id)
         finalists = self._play_single_team(
             team=last_team_standing, gamedb=gamedb, engine=engine)
 
-        log_message("Finalists are {}.".format(pprint.pformat(finalists)), game_id)
+        log_message(message="Finalists are {}.".format(pprint.pformat(finalists)), game_id=self._game_id)
         winner = self._run_finalist_tribe_council(
             finalists=finalists, gamedb=gamedb, engine=engine)
 
-        log_message("Winner is {}.".format(winner), game_id)
+        log_message(message="Winner is {}.".format(winner), game_id=self._game_id)
         return winner
 
     def _play_multi_tribe(self, tribe1: Tribe, tribe2: Tribe, gamedb: Database, engine: Engine) -> Tribe:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         while (tribe1.size > self._options.multi_tribe_min_tribe_size and
                tribe2.size > self._options.multi_tribe_min_tribe_size):
-            log_message("Tribe {} size {} tribe {} size {}.".format(
-                tribe1, tribe1.size, tribe2, tribe2.size), game_id)
+            log_message(message="Tribe {} size {} tribe {} size {}.".format(
+                tribe1, tribe1.size, tribe2, tribe2.size), game_id=self._game_id)
 
-            log_message("Getting new challenge.", game_id)
+            log_message(message="Getting new challenge.", game_id=self._game_id)
             challenge = self._get_challenge(gamedb=gamedb)
 
-            log_message("Running challenge {}.".format(challenge), game_id)
+            log_message(message="Running challenge {}.".format(challenge), game_id=self._game_id)
             self._run_challenge(challenge=challenge,
                                 gamedb=gamedb, engine=engine)
 
-            log_message("Scoring entries for {}.".format(tribe1), game_id)
+            log_message(message="Scoring entries for {}.".format(tribe1), game_id=self._game_id)
             tribe1_score = self._score_entries_tribe_aggregate(tribe=tribe1, challenge=challenge,
                                                                gamedb=gamedb, engine=engine)
 
-            log_message("Scoring entries for {}.".format(tribe2), game_id)
+            log_message(message="Scoring entries for {}.".format(tribe2), game_id=self._game_id)
             tribe2_score = self._score_entries_tribe_aggregate(tribe=tribe2, challenge=challenge,
                                                                gamedb=gamedb, engine=engine)
 
             winning_tribe = tribe1 if tribe1_score > tribe2_score else tribe2
             losing_tribe = tribe1 if winning_tribe == tribe2 else tribe2
 
-            log_message("Running multi-tribe council.", game_id)
+            log_message(message="Running multi-tribe council.", game_id=self._game_id)
             self._run_multi_tribe_council(winning_tribe=winning_tribe, losing_tribe=losing_tribe,
                                           gamedb=gamedb, engine=engine)
 
-            log_message("Merging teams.", game_id)
+            log_message(message="Merging teams.", game_id=self._game_id)
             self._merge_teams(target_team_size=self._options.target_team_size, tribe=losing_tribe,
                               gamedb=gamedb, engine=engine)
 
@@ -102,29 +95,26 @@ class Game(object):
                                   gamedb=gamedb)
 
     def _play_single_tribe(self, tribe: Tribe, gamedb: Database, engine: Engine) -> Team:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         while gamedb.count_teams(active_team_predicate_value=True) > 1:
-            log_message("Teams remaining = {}.".format(
-                gamedb.count_teams(active_team_predicate_value=True)), game_id)
+            log_message(message="Teams remaining = {}.".format(
+                gamedb.count_teams(active_team_predicate_value=True)), game_id=self._game_id)
 
-            log_message("Getting new challenge.", game_id)
+            log_message(message="Getting new challenge.", game_id=self._game_id)
             challenge = self._get_challenge(gamedb=gamedb)
 
-            log_message("Running challenge {}.".format(challenge), game_id)
+            log_message(message="Running challenge {}.".format(challenge), game_id=self._game_id)
             self._run_challenge(challenge=challenge,
                                 gamedb=gamedb, engine=engine)
 
-            log_message("Scoring entries.", game_id)
+            log_message(message="Scoring entries.", game_id=self._game_id)
             winning_teams, losing_teams = self._score_entries_top_k_teams(k=self._options.single_tribe_top_k_threshold,
                                                                           tribe=tribe, challenge=challenge, gamedb=gamedb, engine=engine)
 
-            log_message("Running single tribe council.", game_id)
+            log_message(message="Running single tribe council.", game_id=self._game_id)
             self._run_single_tribe_council(winning_teams=winning_teams, losing_teams=losing_teams,
                                            gamedb=gamedb, engine=engine)
 
-            log_message("Merging teams.", game_id)
+            log_message(message="Merging teams.", game_id=self._game_id)
             self._merge_teams(target_team_size=self._options.target_team_size, tribe=tribe, gamedb=gamedb,
                               engine=engine)
 
@@ -143,14 +133,11 @@ class Game(object):
         return gamedb.list_players(from_team=team)
 
     def _get_voted_out_player(self, team: Team, gamedb: Database) -> [Player, None]:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         high = 0
         candidates = []
-        log_message("Counting votes from team {}.".format(team), game_id)
+        log_message(message="Counting votes from team {}.".format(team), game_id=self._game_id)
         team_votes = gamedb.count_votes(from_team=team)
-        log_message("Got votes {}.".format(pprint.pformat(team_votes)), game_id)
+        log_message(message="Got votes {}.".format(pprint.pformat(team_votes)), game_id=self._game_id)
 
         for _, votes in team_votes.items():
             if votes > high:
@@ -170,13 +157,9 @@ class Game(object):
 
     # fraction of teams in losing tribe must vote
     def _run_multi_tribe_council(self, winning_tribe: Tribe, losing_tribe: Tribe, gamedb: Database, engine: Engine):
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
-
         non_immune_teams = list()
         for team in gamedb.stream_teams(from_tribe=losing_tribe):
-            log_message("Found losing team {}.".format(team), game_id)
+            log_message(message="Found losing team {}.".format(team), game_id=self._game_id)
             immunity_granted = random.random() < self._options.multi_tribe_team_immunity_likelihood
             if not immunity_granted:
                 non_immune_teams.append(team)
@@ -193,17 +176,17 @@ class Game(object):
         # wait for votes
         while (((_unixtime() - tribal_council_start_timestamp)
                 < self._options.multi_tribe_council_time_sec) and not self._stop.is_set()):
-            log_message("Waiting for tribal council to end.", game_id)
+            log_message(message="Waiting for tribal council to end.", game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
 
         # count votes
         for team in non_immune_teams:
-            log_message("Counting votes for non-immune team {}.".format(team), game_id)
+            log_message(message="Counting votes for non-immune team {}.".format(team), game_id=self._game_id)
             voted_out_player = self._get_voted_out_player(
                 team=team, gamedb=gamedb)
             if voted_out_player:
                 gamedb.deactivate_player(player=voted_out_player)
-                log_message("Deactivated player {}.".format(voted_out_player), game_id)
+                log_message(message="Deactivated player {}.".format(voted_out_player), game_id=self._game_id)
                 engine.add_event(events.NotifyPlayerVotedOutEvent(game_id=self._game_id, game_options=self._options,
                                                                   player=voted_out_player))
 
@@ -216,9 +199,6 @@ class Game(object):
                                   gamedb: Database, engine: Engine):
 
         # announce winner and tribal council for losing teams
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         gamedb.clear_votes()
         engine.add_event(events.NotifySingleTribeCouncilEvent(
             game_id=self._game_id, game_options=self._options,
@@ -228,7 +208,7 @@ class Game(object):
         # wait for votes
         while (((_unixtime() - tribal_council_start_timestamp)
                 < self._options.single_tribe_council_time_sec) and not self._stop.is_set()):
-            log_message("Waiting for tribal council to end.", game_id)
+            log_message(message="Waiting for tribal council to end.", game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
 
         # count votes
@@ -237,13 +217,13 @@ class Game(object):
                 team=team, gamedb=gamedb)
             if voted_out_player:
                 gamedb.deactivate_player(player=voted_out_player)
-                log_message("Deactivated player {}.".format(voted_out_player), game_id)
+                log_message(message="Deactivated player {}.".format(voted_out_player), game_id=self._game_id)
                 engine.add_event(events.NotifyPlayerVotedOutEvent(game_id=self._game_id, game_options=self._options,
                                                                   player=voted_out_player))
             else:
-                log_message("For some reason no one got voted out...", game_id)
-                log_message("Players = {}.".format(
-                    pprint.pformat(gamedb.list_players(from_team=team))), game_id)
+                log_message(message="For some reason no one got voted out...", game_id=self._game_id)
+                log_message(message="Players = {}.".format(
+                    pprint.pformat(gamedb.list_players(from_team=team))), game_id=self._game_id)
 
         # notify all players of what happened at tribal council
         engine.add_event(
@@ -251,9 +231,6 @@ class Game(object):
 
     def _run_single_team_council(self, team: Team, losing_players: List[Player], gamedb: Database, engine: Engine):
         # announce winner and tribal council for losing teams
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         gamedb.clear_votes()
 
         winning_player = [player for player in gamedb.list_players(
@@ -265,14 +242,14 @@ class Game(object):
         # wait for votes
         while (((_unixtime() - tribal_council_start_timestamp)
                 < self._options.single_team_council_time_sec) and not self._stop.is_set()):
-            log_message("Waiting for tribal council to end.", game_id)
+            log_message(message="Waiting for tribal council to end.", game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
 
         # count votes
         voted_out_player = self._get_voted_out_player(team=team, gamedb=gamedb)
         if voted_out_player:
             gamedb.deactivate_player(player=voted_out_player)
-            log_message("Deactivated player {}.".format(voted_out_player), game_id)
+            log_message(message="Deactivated player {}.".format(voted_out_player), game_id=self._game_id)
             engine.add_event(events.NotifyPlayerVotedOutEvent(game_id=self._game_id, game_options=self._options,
                                                               player=voted_out_player))
 
@@ -281,9 +258,6 @@ class Game(object):
             events.NotifyTribalCouncilCompletionEvent(game_id=self._game_id, game_options=self._options))
 
     def _run_finalist_tribe_council(self, finalists: List[Player], gamedb: Database, engine: Engine) -> Player:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         gamedb.clear_votes()
 
         engine.add_event(
@@ -294,7 +268,7 @@ class Game(object):
         # wait for votes
         while (((_unixtime() - tribal_council_start_timestamp)
                 < self._options.final_tribal_council_time_sec) and not self._stop.is_set()):
-            log_message("Waiting for tribal council to end.", game_id)
+            log_message(message="Waiting for tribal council to end.", game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
 
         # count votes
@@ -318,28 +292,25 @@ class Game(object):
         # choice is to keep team sizes as close to the intended size as possible
 
         # find all teams with size = 2, these players need to be merged
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         small_teams = gamedb.stream_teams(
             from_tribe=tribe, team_size_predicate_value=2)
         merge_candidates = Queue()
 
         for team in small_teams:
-            log_message("Found team of 2. Deacticating team {}.".format(team), game_id)
+            log_message(message="Found team of 2. Deacticating team {}.".format(team), game_id=self._game_id)
 
             # do not deactivate the last active team in the tribe
             if gamedb.count_teams(from_tribe=tribe, active_team_predicate_value=True) > 1:
                 gamedb.deactivate_team(team)
 
             for player in gamedb.list_players(from_team=team):
-                log_message("Adding merge candidate {}.".format(player), game_id)
+                log_message(message="Adding merge candidate {}.".format(player), game_id=self._game_id)
                 merge_candidates.put(player)
 
         sorted_teams = gamedb.stream_teams(
             from_tribe=tribe, order_by_size=True, descending=False)
 
-        log_message("Redistributing merge candidates...", game_id)
+        log_message(message="Redistributing merge candidates...", game_id=self._game_id)
         # round robin redistribution strategy
         # simplest case, could use more thought.
         visited = {}
@@ -349,16 +320,16 @@ class Game(object):
                 visited[team.id] = True
 
                 if (team.size >= target_team_size and other_options_available):
-                    log_message("Team {} has size >= target {} and other options are available. "
-                                "Continuing search...".format(team, target_team_size), game_id)
+                    log_message(message="Team {} has size >= target {} and other options are available. "
+                                "Continuing search...".format(team, target_team_size), game_id=self._game_id)
                     continue
 
                 player = merge_candidates.get()
                 if player.team_id == team.id:
                     continue
 
-                log_message("Merging player {} from team {} into team {}.".format(
-                    player, player.team_id, team.id), game_id)
+                log_message(message="Merging player {} from team {} into team {}.".format(
+                    player, player.team_id, team.id), game_id=self._game_id)
                 player.team_id = team.id
                 team.size = team.size + 1
                 gamedb.save(team)
@@ -369,12 +340,9 @@ class Game(object):
                                                                     team=team))
 
     def _get_challenge(self, gamedb: Database) -> Challenge:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         available_challenge_count = 0
         while available_challenge_count == 0 and not self._stop.is_set():
-            log_message("Waiting for next challenge to become available.", game_id)
+            log_message(message="Waiting for next challenge to become available.", game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
             available_challenges = gamedb.list_challenges(
                 challenge_completed_predicate_value=False)
@@ -383,12 +351,9 @@ class Game(object):
 
     def _run_challenge(self, challenge: Challenge, gamedb: Database, engine: Engine):
         # wait for challenge to begin
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         while (_unixtime() < challenge.start_timestamp) and not self._stop.is_set():
-            log_message("Waiting {}s for challenge to {} to begin.".format(
-                challenge.start_timestamp - _unixtime(), challenge), game_id)
+            log_message(message="Waiting {}s for challenge to {} to begin.".format(
+                challenge.start_timestamp - _unixtime(), challenge), game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
 
         # notify players
@@ -397,8 +362,8 @@ class Game(object):
 
         # wait for challenge to end
         while (_unixtime() < challenge.end_timestamp) and not self._stop.is_set():
-            log_message("Waiting {}s for challenge to {} to end.".format(
-                challenge.end_timestamp - _unixtime(), challenge), game_id)
+            log_message(message="Waiting {}s for challenge to {} to end.".format(
+                challenge.end_timestamp - _unixtime(), challenge), game_id=self._game_id)
             time.sleep(self._options.game_wait_sleep_interval_sec)
 
         challenge.complete = True
@@ -424,9 +389,6 @@ class Game(object):
                 break
 
     def _score_entries_tribe_aggregate(self, tribe: Tribe, challenge: Challenge, gamedb: Database, engine: Engine):
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         score_dict = {'score': 0}
         players = gamedb.count_players(from_tribe=tribe)
         entries = gamedb.stream_entries(
@@ -437,19 +399,16 @@ class Game(object):
                             entries=entries, challenge=challenge, score_dict=score_dict, gamedb=gamedb, engine=engine)
 
         # tribe score = avg score of all tribe members
-        log_message("_score_entries_tribe_agg = {}.".format(
-            score_dict['score']), game_id)
+        log_message(message="_score_entries_tribe_agg = {}.".format(
+            score_dict['score']), game_id=self._game_id)
         return score_dict['score'] / players
 
     def _score_entries_top_k_teams_fn(self, entries: Iterable, challenge: Challenge, score_dict: Dict, gamedb: Database, engine: Engine):
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         entries_iter = iter(entries)
         while not self._stop.is_set():
             try:
                 entry = next(entries_iter)
-                log_message("Entry {}.".format(entry), game_id)
+                log_message(message="Entry {}.".format(entry), game_id=self._game_id)
                 points = entry.likes / entry.views
                 player = gamedb.player_from_id(entry.player_id)
                 engine.add_event(events.NotifyPlayerScoreEvent(game_id=self._game_id, game_options=self._options,
@@ -465,9 +424,6 @@ class Game(object):
 
     def _score_entries_top_k_teams(self, k: float, tribe: Tribe, challenge: Challenge, gamedb: Database,
                                    engine: Engine) -> Tuple[List[Team], List[Team]]:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         team_scores = {}
         top_scores = list()
         winning_teams = list()
@@ -485,38 +441,35 @@ class Game(object):
                                         team_id))
 
         rank_threshold = float(k * len(top_scores))
-        log_message("Rank threshold = {}".format(rank_threshold), game_id)
+        log_message(message="Rank threshold = {}".format(rank_threshold), game_id=self._game_id)
 
         # note that the default python heap pops in ascending order,
         # so the rank here is actually worst to best.
         num_scores = len(top_scores)
         if num_scores == 1:
             score, team_id = heapq.heappop(top_scores)
-            log_message("Winner {}.".format(team_id), game_id)
+            log_message(message="Winner {}.".format(team_id), game_id=self._game_id)
             winning_teams = [gamedb.team_from_id(team_id)]
         else:
             for rank in range(num_scores):
                 score, team_id = heapq.heappop(top_scores)
-                log_message("Team {} rank {} with score {}.".format(
-                    team_id, rank, score), game_id)
+                log_message(message="Team {} rank {} with score {}.".format(
+                    team_id, rank, score), game_id=self._game_id)
                 if rank >= rank_threshold:
-                    log_message("Winner {}.".format(team_id), game_id)
+                    log_message(message="Winner {}.".format(team_id), game_id=self._game_id)
                     winning_teams.append(gamedb.team_from_id(team_id))
                 else:
-                    log_message("Loser {}.".format(team_id), game_id)
+                    log_message(message="Loser {}.".format(team_id), game_id=self._game_id)
                     losing_teams.append(gamedb.team_from_id(team_id))
 
         return (winning_teams, losing_teams)
 
     def _score_entries_top_k_players_fn(self, entries: Iterable, challenge: Challenge, score_dict: Dict, gamedb: Database, engine: Engine):
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         entries_iter = iter(entries)
         while not self._stop.is_set():
             try:
                 entry = next(entries_iter)
-                log_message("Entry {}.".format(entry), game_id)
+                log_message(message="Entry {}.".format(entry), game_id=self._game_id)
                 points = entry.likes / entry.views
                 player = gamedb.player_from_id(entry.player_id)
                 engine.add_event(events.NotifyPlayerScoreEvent(game_id=self._game_id, game_options=self._options,
@@ -527,9 +480,6 @@ class Game(object):
                 break
 
     def _score_entries_top_k_players(self, team: Team, challenge: Challenge, gamedb: Database, engine: Engine) -> List[Player]:
-        game_id = ""
-        if hasattr(self, '_game_id'):
-            game_id = self._game_id
         player_scores = {}
         top_scores = list()
         losing_players = list()
@@ -552,8 +502,8 @@ class Game(object):
         else:
             for rank in range(num_scores):
                 score, player_id = heapq.heappop(top_scores)
-                log_message("Player {} rank {} with score {}.".format(
-                    player_id, rank, score), game_id)
+                log_message(message="Player {} rank {} with score {}.".format(
+                    player_id, rank, score), game_id=self._game_id)
 
                 # all but the highest scorer lose
                 if rank < (num_scores - 1):
@@ -574,6 +524,7 @@ if __name__ == '__main__':
     # TODO(brandon) for production each game should instantiate a separate AWS FIFO
     # on the fly.
     engine = Engine(options=options,
+                    game_id=self._game_id,
                     sqs_config_path=_AMAZON_SQS_PROD_CONF_JSON_PATH)
     database = FirestoreDB(json_config_path=_FIRESTORE_PROD_CONF_JSON_PATH)
     game.play(tribe1=database.tribe_from_id(_TRIBE_1_ID),

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -10,6 +10,12 @@ from datetime import date
 import enum
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+import sentry_sdk
+sentry_sdk.init(dsn='https://c6e27a09424a4e4e8ac19e7c82fc9941@o391367.ingest.sentry.io/5237391',
+                attach_stacktrace=True)
+from sentry_sdk import capture_message
+
+
 
 
 class GameError(Exception):
@@ -212,4 +218,5 @@ class Serializable(object):
 
 
 def log_message(message):
+    capture_message('Something went wrong')
     logging.info(message)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -14,6 +14,8 @@ import sentry_sdk
 sentry_sdk.init(dsn='https://c6e27a09424a4e4e8ac19e7c82fc9941@o391367.ingest.sentry.io/5237391',
                 attach_stacktrace=True)
 from sentry_sdk import capture_message
+from sentry_sdk import configure_scope
+
 
 
 
@@ -217,6 +219,9 @@ class Serializable(object):
         return json.dumps(self.to_dict())
 
 
-def log_message(message):
+def log_message(message, game_id="9999999999"):
+    with configure_scope() as scope:
+        scope.set_tag("game_id", game_id)
+
     capture_message('Something went wrong')
     logging.info(message)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -200,23 +200,7 @@ class Serializable(object):
         tiktok=""
         team_id=""
         tribe_id=""
-        print("PRINTING DIRR")
-        print(dir(self))
-        if hasattr(self, 'recipient_phone_numbers'):
-            nums=self.recipient_phone_numbers
-        elif hasattr(self, 'phone_number'):
-            nums=self.phone_number
-        if hasattr(self, 'tiktok'):
-            tiktok=self.tiktok
-        if hasattr(self, 'team_id'):
-            team_id=self.team_id
-        if hasattr(self, 'tribe_id'):
-            tribe_id=self.tribe_id
-        log_message('to_dict called for {}'.format(self.__class__),
-                    phone_numbers=nums,
-                    tiktok=tiktok,
-                    team_id=team_id,
-                    tribe_id=tribe_id)
+        log_message('to_dict called for {}'.format(self.__class__), self)
         d = {'class': self.__class__.__name__}
         for k, v in vars(self).items():
             d[k] = self._to_dict_item(v)
@@ -240,32 +224,52 @@ class Serializable(object):
         return json.dumps(self.to_dict())
 
 
-def log_message(message="Something went wrong", game_id="", player_id="",
-                phone_numbers=[], tiktok="", tribe_id="", team_id=""):
+def log_message(message, game_attributes):
+    #game_attributes is usually self
     print("LOG_MESSAGE CALLED --------------------")
+    phone_numbers=[]
+    tiktok=""
+    team_id=""
+    tribe_id=""
+    game_id=""
+    player_id=""
+    if game_attributes:
+        if hasattr(game_attributes, 'recipient_phone_numbers'):
+            phone_numbers=game_attributes.recipient_phone_numbers
+        elif hasattr(game_attributes, 'phone_number'):
+            phone_numbers=game_attributes.phone_number
+        if hasattr(game_attributes, 'tiktok'):
+            tiktok=game_attributes.tiktok
+        if hasattr(game_attributes, 'team_id'):
+            team_id=game_attributes.team_id
+        if hasattr(game_attributes, 'tribe_id'):
+            tribe_id=game_attributes.tribe_id
+
     with push_scope() as scope:
         if phone_numbers:
             #sometimes phone_numbers is not a list
             if (isinstance(phone_numbers, list)):
                 for index, num in enumerate(phone_numbers):
                     scope.set_tag("phone_number"+str(index), num)
+                    print("phone_number"+str(index) +" " + num)
             else:
                 scope.set_tag("phone_number", phone_numbers)
+                print("phone_number " + phone_numbers)
 
         if game_id:
-            print("gameid"+game_id)
+            print("game_id "+game_id)
             scope.set_tag("game_id", game_id)
 
         if player_id:
-            print("player_id"+player_id)
+            print("player_id "+player_id)
             scope.set_tag("player_id", player_id)
 
         if tiktok:
-            print("tiktok"+tiktok)
+            print("tiktok "+tiktok)
             scope.set_tag("tiktok_hash", tiktok)
 
         if team_id:
-            print("team_id"+team_id)
+            print("team_id "+team_id)
             scope.set_tag("team_id", team_id)
 
         # capture_message(message)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -282,5 +282,6 @@ def log_message(message, game_attributes):
             print("team_id "+team_id)
             scope.set_tag("team_id", team_id)
 
+        #UNCOMMENT THE BELOW LINE TO ENABLE SENTRY CALLS
         #capture_message(message)
         logging.info(message)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -11,8 +11,6 @@ import enum
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 import sentry_sdk
-sentry_sdk.init(dsn='https://7ece3e1e345248a19475ea1ed503d28e@o391894.ingest.sentry.io/5238617',
-                attach_stacktrace=True)
 from sentry_sdk import capture_message
 from sentry_sdk import configure_scope
 from sentry_sdk import push_scope
@@ -230,10 +228,13 @@ class Serializable(object):
     def to_json(self):
         return json.dumps(self.to_dict())
 
+def init_sentry():
+    sentry_sdk.init(dsn='https://7ece3e1e345248a19475ea1ed503d28e@o391894.ingest.sentry.io/5238617',
+                    attach_stacktrace=True)
 
 def log_message(message: Text, game_id: Text = None, additional_tags: Dict = None, push_to_sentry=False):
-    print("LOG_MESSAGE CALLED --------------------")
-
+    if push_to_sentry:
+        init_sentry()#sentry automatically pushes exceptions. to avoid this in local env, only init sentry when needed
     with push_scope() as scope:
         if additional_tags:
             for tag, value in additional_tags.items():
@@ -246,5 +247,6 @@ def log_message(message: Text, game_id: Text = None, additional_tags: Dict = Non
 
         if push_to_sentry:
             logging.info("pushing to sentry")
-            #capture_message(message)
+            capture_message(message)
+
         logging.info(message)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -196,7 +196,27 @@ class Serializable(object):
                 'Serializable object contains unsupported attribute {}'.format(v))
 
     def to_dict(self):
-        log_message('to_dict called for {}'.format(self.__class__), phone_numbers=self.recipient_phone_numbers)
+        nums=[]
+        tiktok=""
+        team_id=""
+        tribe_id=""
+        print("PRINTING DIRR")
+        print(dir(self))
+        if hasattr(self, 'recipient_phone_numbers'):
+            nums=self.recipient_phone_numbers
+        elif hasattr(self, 'phone_number'):
+            nums=self.phone_number
+        if hasattr(self, 'tiktok'):
+            tiktok=self.tiktok
+        if hasattr(self, 'team_id'):
+            team_id=self.team_id
+        if hasattr(self, 'tribe_id'):
+            tribe_id=self.tribe_id
+        log_message('to_dict called for {}'.format(self.__class__),
+                    phone_numbers=nums,
+                    tiktok=tiktok,
+                    team_id=team_id,
+                    tribe_id=tribe_id)
         d = {'class': self.__class__.__name__}
         for k, v in vars(self).items():
             d[k] = self._to_dict_item(v)
@@ -220,16 +240,17 @@ class Serializable(object):
         return json.dumps(self.to_dict())
 
 
-def log_message( message="Something went wrong", game_id="", player_id="", phone_numbers=[]):
+def log_message(message="Something went wrong", game_id="", player_id="",
+                phone_numbers=[], tiktok="", tribe_id="", team_id=""):
+    print("LOG_MESSAGE CALLED --------------------")
     with push_scope() as scope:
         if phone_numbers:
-            #sometimes phone_numbers is not a list. why?
+            #sometimes phone_numbers is not a list
             if (isinstance(phone_numbers, list)):
                 for index, num in enumerate(phone_numbers):
                     scope.set_tag("phone_number"+str(index), num)
             else:
                 scope.set_tag("phone_number", phone_numbers)
-
 
         if game_id:
             print("gameid"+game_id)
@@ -239,7 +260,15 @@ def log_message( message="Something went wrong", game_id="", player_id="", phone
             print("player_id"+player_id)
             scope.set_tag("player_id", player_id)
 
-        capture_message(message)
+        if tiktok:
+            print("tiktok"+tiktok)
+            scope.set_tag("tiktok_hash", tiktok)
+
+        if team_id:
+            print("team_id"+team_id)
+            scope.set_tag("team_id", team_id)
+
+        # capture_message(message)
         logging.info(message)
         logging.info(game_id)
         logging.info(phone_numbers)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -238,12 +238,22 @@ def log_message(message, game_attributes):
             phone_numbers=game_attributes.recipient_phone_numbers
         elif hasattr(game_attributes, 'phone_number'):
             phone_numbers=game_attributes.phone_number
+        if hasattr(game_attributes, 'game_id'):
+            game_id=game_attributes.game_id
+        elif hasattr(game_attributes, '_game_id'):
+            game_id=game_attributes._game_id
         if hasattr(game_attributes, 'tiktok'):
             tiktok=game_attributes.tiktok
+        elif hasattr(game_attributes, '_tiktok'):
+            tiktok=game_attributes._tiktok
         if hasattr(game_attributes, 'team_id'):
             team_id=game_attributes.team_id
+        if hasattr(game_attributes, '_team_id'):
+            team_id=game_attributes._team_id
         if hasattr(game_attributes, 'tribe_id'):
             tribe_id=game_attributes.tribe_id
+        if hasattr(game_attributes, '_tribe_id'):
+            tribe_id=game_attributes._tribe_id
 
     with push_scope() as scope:
         if phone_numbers:
@@ -272,7 +282,5 @@ def log_message(message, game_attributes):
             print("team_id "+team_id)
             scope.set_tag("team_id", team_id)
 
-        # capture_message(message)
+        #capture_message(message)
         logging.info(message)
-        logging.info(game_id)
-        logging.info(phone_numbers)

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -11,7 +11,7 @@ import enum
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 import sentry_sdk
-sentry_sdk.init(dsn='https://c6e27a09424a4e4e8ac19e7c82fc9941@o391367.ingest.sentry.io/5237391',
+sentry_sdk.init(dsn='https://7ece3e1e345248a19475ea1ed503d28e@o391894.ingest.sentry.io/5238617',
                 attach_stacktrace=True)
 from sentry_sdk import capture_message
 from sentry_sdk import configure_scope

--- a/backend/game_engine/common.py
+++ b/backend/game_engine/common.py
@@ -194,18 +194,6 @@ class Serializable(object):
                 'Serializable object contains unsupported attribute {}'.format(v))
 
     def to_dict(self):
-        def massage_for_logging(attrs_dict):
-            if hasattr(self, 'recipient_phone_numbers'):
-                #sometimes phone_numbers is not a list
-                if (isinstance(self.recipient_phone_numbers, list)):
-                    for index, num in enumerate(self.recipient_phone_numbers):
-                        attrs_dict["phone_number" + str(index)] = num
-                else:
-                    attrs_dict["phone_number0"] = self.recipient_phone_numbers
-            return attrs_dict
-        attrs_dict = massage_for_logging({})
-        log_message('to_dict called for {}'.format(self.__class__),
-                    additional_tags=attrs_dict)
         d = {'class': self.__class__.__name__}
         for k, v in vars(self).items():
             d[k] = self._to_dict_item(v)
@@ -232,9 +220,10 @@ def init_sentry():
     sentry_sdk.init(dsn='https://7ece3e1e345248a19475ea1ed503d28e@o391894.ingest.sentry.io/5238617',
                     attach_stacktrace=True)
 
-def log_message(message: Text, game_id: Text = None, additional_tags: Dict = None, push_to_sentry=False):
+def log_message(message: Text, game_id: Text = None, additional_tags: Dict = None, push_to_sentry = False):
     if push_to_sentry:
-        init_sentry()#sentry automatically pushes exceptions. to avoid this in local env, only init sentry when needed
+        # Sentry automatically pushes exceptions. To avoid this in local env, only init sentry when needed
+        init_sentry()
     with push_scope() as scope:
         if additional_tags:
             for tag, value in additional_tags.items():

--- a/backend/game_engine/engine.py
+++ b/backend/game_engine/engine.py
@@ -47,7 +47,7 @@ class Engine(object):
                 if hasattr(event, "game_id"):
                     game_id = event.game_id
                 log_message(
-                    'Engine worker processing event {}'.format(event.to_json()), game_id)#TODO test this
+                    'Engine worker processing event {}'.format(event.to_json()), game_id)
                 notifier.send(sms_event_messages=event.messages)
             except Exception as e:
                 log_message(

--- a/backend/game_engine/engine.py
+++ b/backend/game_engine/engine.py
@@ -32,7 +32,7 @@ class Engine(object):
         self._output_events.put(event, blocking=False)
 
     def stop(self):
-        log_message('Shutting down all engine workers.', self)
+        log_message('Shutting down all engine workers.')
         self._stop.set()
 
     def _do_work_fn(self) -> None:
@@ -41,15 +41,16 @@ class Engine(object):
         notifier = TwilioSMSNotifier(json_config_path=self._twilio_config_path)
         while not self._stop.is_set():
             try:
-                log_message('Getting event from queue...', self)
+                log_message('Getting event from queue...')
                 event = queue.get()
+                game_id = ""
+                if hasattr(event, "game_id"):
+                    game_id = event.game_id
                 log_message(
-                    'Engine worker processing event {}'.format(event.to_json()), event)#TODO test this
+                    'Engine worker processing event {}'.format(event.to_json()), game_id)#TODO test this
                 notifier.send(sms_event_messages=event.messages)
             except Exception as e:
                 log_message(
-                    'Engine worker failed with exception {}.'.format(e),
-                    self)
+                    'Engine worker failed with exception {}.'.format(e))
         log_message('Shutting down workder thread {}.'.format(
-            threading.current_thread().ident),
-                    self)
+            threading.current_thread().ident))

--- a/backend/game_engine/engine.py
+++ b/backend/game_engine/engine.py
@@ -32,7 +32,7 @@ class Engine(object):
         self._output_events.put(event, blocking=False)
 
     def stop(self):
-        log_message('Shutting down all engine workers.')
+        log_message('Shutting down all engine workers.')#no state info
         self._stop.set()
 
     def _do_work_fn(self) -> None:
@@ -44,7 +44,7 @@ class Engine(object):
                 log_message('Getting event from queue...')
                 event = queue.get()
                 log_message(
-                    'Engine worker processing event {}'.format(event.to_json()))
+                    'Engine worker processing event {}'.format(event.to_json()), game_id=event.game_id)#TODO test this
                 notifier.send(sms_event_messages=event.messages)
             except Exception as e:
                 log_message(

--- a/backend/game_engine/engine.py
+++ b/backend/game_engine/engine.py
@@ -32,7 +32,7 @@ class Engine(object):
         self._output_events.put(event, blocking=False)
 
     def stop(self):
-        log_message('Shutting down all engine workers.')#no state info
+        log_message('Shutting down all engine workers.', self)
         self._stop.set()
 
     def _do_work_fn(self) -> None:
@@ -41,13 +41,15 @@ class Engine(object):
         notifier = TwilioSMSNotifier(json_config_path=self._twilio_config_path)
         while not self._stop.is_set():
             try:
-                log_message('Getting event from queue...')
+                log_message('Getting event from queue...', self)
                 event = queue.get()
                 log_message(
-                    'Engine worker processing event {}'.format(event.to_json()), game_id=event.game_id)#TODO test this
+                    'Engine worker processing event {}'.format(event.to_json()), event)#TODO test this
                 notifier.send(sms_event_messages=event.messages)
             except Exception as e:
                 log_message(
-                    'Engine worker failed with exception {}.'.format(e))
+                    'Engine worker failed with exception {}.'.format(e),
+                    self)
         log_message('Shutting down workder thread {}.'.format(
-            threading.current_thread().ident))
+            threading.current_thread().ident),
+                    self)

--- a/backend/game_engine/events.py
+++ b/backend/game_engine/events.py
@@ -112,13 +112,13 @@ class AmazonSQS(EventQueue):
             ],
             MaxNumberOfMessages=1,
             WaitTimeSeconds=20)
-        log_message(str(response))
+        log_message(str(response), self)
 
         if 'Messages' in response:
             message = response['Messages'][0]
             message_body = message['Body']
             log_message(
-                'Received event with message body {}'.format(message_body))
+                'Received event with message body {}'.format(message_body), self)
             self._delete_message(message['ReceiptHandle'])
             return SMSEvent.from_json(json_text=message_body, game_options=self._game_options)
         else:
@@ -126,15 +126,16 @@ class AmazonSQS(EventQueue):
 
     def put_fn(self, event: SMSEvent) -> None:
         # TODO(brandon) add retry logic and error handling.
+        print(dir(event))
         log_message("Putting {} on queue {}.".format(
-            event.to_json(), self._url))
+            event.to_json(), self._url), event)
         response = self._client.send_message(
             QueueUrl=self._url,
             MessageBody=event.to_json(),
             MessageGroupId=event.game_id,
             MessageDeduplicationId=str(uuid.uuid4())
         )
-        log_message(response)
+        log_message(response, event)
 
     def put(self, event: SMSEvent, blocking: bool = False) -> None:
         if blocking:

--- a/backend/game_engine/events.py
+++ b/backend/game_engine/events.py
@@ -8,7 +8,6 @@ from game_engine import messages
 from typing import Iterable, List
 import boto3
 import json
-import logging
 import sys
 from concurrent.futures import ThreadPoolExecutor
 import copy
@@ -84,7 +83,8 @@ class EventQueueError(Exception):
 
 
 class AmazonSQS(EventQueue):
-    def __init__(self, json_config_path: Text, game_options: GameOptions = None) -> None:
+    def __init__(self, json_config_path: Text, game_id: Text, game_options: GameOptions = None) -> None:
+        self.game_id = game_id
         with open(json_config_path, 'r') as f:
             config = json.loads(f.read())
             self._url = config['url']
@@ -105,9 +105,6 @@ class AmazonSQS(EventQueue):
                                     ReceiptHandle=receipt_handle)
 
     def get(self) -> SMSEvent:
-        game_id = ""
-        if hasattr(self, "game_id"):
-            game_id = self.game_id
         response = self._client.receive_message(
             QueueUrl=self._url,
             MessageAttributeNames=[
@@ -115,13 +112,13 @@ class AmazonSQS(EventQueue):
             ],
             MaxNumberOfMessages=1,
             WaitTimeSeconds=20)
-        log_message(str(response), game_id)
+        log_message(message=str(response), game_id=self.game_id)
 
         if 'Messages' in response:
             message = response['Messages'][0]
             message_body = message['Body']
             log_message(
-                'Received event with message body {}'.format(message_body), game_id)
+                message='Received event with message body {}'.format(message_body), game_id=self.game_id)
             self._delete_message(message['ReceiptHandle'])
             return SMSEvent.from_json(json_text=message_body, game_options=self._game_options)
         else:
@@ -129,18 +126,15 @@ class AmazonSQS(EventQueue):
 
     def put_fn(self, event: SMSEvent) -> None:
         # TODO(brandon) add retry logic and error handling.
-        game_id = ""
-        if hasattr(event, "game_id"):
-            game_id = event.game_id
-        log_message("Putting {} on queue {}.".format(
-            event.to_json(), self._url), game_id)
+        log_message(message="Putting {} on queue {}.".format(
+            event.to_json(), self._url), game_id=self.game_id)
         response = self._client.send_message(
             QueueUrl=self._url,
             MessageBody=event.to_json(),
             MessageGroupId=event.game_id,
             MessageDeduplicationId=str(uuid.uuid4())
         )
-        log_message(response, game_id)
+        log_message(message=response, game_id=self.game_id)
 
     def put(self, event: SMSEvent, blocking: bool = False) -> None:
         if blocking:

--- a/backend/game_engine/firestore.py
+++ b/backend/game_engine/firestore.py
@@ -23,9 +23,6 @@ _THREAD_POOL_SIZE = 100
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
-def _log_message(message):
-    logging.info(message)
-
 
 class FirestoreData(Data):
     """This class wraps firebase objects with dynamically assigned

--- a/backend/game_engine/twilio.py
+++ b/backend/game_engine/twilio.py
@@ -61,7 +61,7 @@ class TwilioSMSNotifier(SMSNotifier):
             to_binding=[
                 json.dumps({'binding_type': 'sms', 'address': self._normalize_sms_address(address)}) for address in recipient_addresses],
             body=self._normalize_sms_message(message))
-        log_message(str(notification.sid), self)#TODO test this
+        log_message(str(notification.sid))
 
     def send_sms(self, message: Text, recipient_address: Text) -> None:
         message = self._client.messages \

--- a/backend/game_engine/twilio.py
+++ b/backend/game_engine/twilio.py
@@ -25,12 +25,13 @@ class SMSNotifier(ABC):
 
 class TwilioSMSNotifier(SMSNotifier):
 
-    def __init__(self, json_config_path: Text):
+    def __init__(self, json_config_path: Text, game_id: Text):
         with open(json_config_path, 'r') as f:
             config = json.loads(f.read())
             self._client = Client(config['account_sid'], config['auth_token'])
             self._notify_service_sid = config['notify_service_sid']
             self._phone_number = config['phone_number']
+            self._game_id = game_id
 
     def send(self, sms_event_messages: Iterable[SMSEventMessage]) -> None:
         for m in sms_event_messages:
@@ -61,7 +62,7 @@ class TwilioSMSNotifier(SMSNotifier):
             to_binding=[
                 json.dumps({'binding_type': 'sms', 'address': self._normalize_sms_address(address)}) for address in recipient_addresses],
             body=self._normalize_sms_message(message))
-        log_message(str(notification.sid))
+        log_message(message=str(notification.sid), game_id=self._game_id, additional_tags={"phone_number":self._phone_number})
 
     def send_sms(self, message: Text, recipient_address: Text) -> None:
         message = self._client.messages \

--- a/backend/game_engine/twilio.py
+++ b/backend/game_engine/twilio.py
@@ -61,7 +61,7 @@ class TwilioSMSNotifier(SMSNotifier):
             to_binding=[
                 json.dumps({'binding_type': 'sms', 'address': self._normalize_sms_address(address)}) for address in recipient_addresses],
             body=self._normalize_sms_message(message))
-        log_message(str(notification.sid))
+        log_message(str(notification.sid), self)#TODO test this
 
     def send_sms(self, message: Text, recipient_address: Text) -> None:
         message = self._client.messages \

--- a/backend/test_engine.py
+++ b/backend/test_engine.py
@@ -159,6 +159,7 @@ class EngineTest(unittest.TestCase):
     def test_event_processing(self, send_fn):
         engine = Engine(
             options=self._game_options,
+            game_id=_TEST_GAME_ID,
             sqs_config_path=_TEST_AMAZON_SQS_CONFIG_PATH,
             twilio_config_path=_TEST_TWILIO_SMS_CONFIG_PATH,
             gamedb=_gamedb

--- a/backend/test_events.py
+++ b/backend/test_events.py
@@ -73,7 +73,7 @@ _TEST_TRIBE2 = Tribe(
 
 @contextmanager
 def aws_test_queue() -> AmazonSQS:
-    sqs = AmazonSQS(json_config_path=_TEST_AMAZON_SQS_CONFIG_PATH)
+    sqs = AmazonSQS(json_config_path=_TEST_AMAZON_SQS_CONFIG_PATH, game_id=_TEST_GAME_ID)
     try:
         queue = sqs._client.create_queue(
             QueueName="{}.fifo".format(str(uuid.uuid4())),

--- a/backend/test_messages.py
+++ b/backend/test_messages.py
@@ -313,7 +313,8 @@ class SMSMessageUXTest(unittest.TestCase):
         self.game_options = GameOptions()
         self.game_options.game_schedule = STV_I18N_TABLE['US']
         self.twilio = TwilioSMSNotifier(
-            json_config_path=_TEST_TWILIO_SMS_CONFIG_PATH)
+            json_config_path=_TEST_TWILIO_SMS_CONFIG_PATH,
+            game_id=_TEST_GAME_ID)
 
     def test_notify_player_score_event_msg(self):
         event = events.NotifyPlayerScoreEvent(

--- a/backend/test_twilio.py
+++ b/backend/test_twilio.py
@@ -12,11 +12,12 @@ import mock
 from twilio.rest import Client
 
 _TEST_TWILIO_SMS_CONFIG_PATH = '../twilio/stv-twilio-service-test.json'
-
+_TEST_GAME_ID = "f49f0cfd-c93b-4132-8c5b-ebea4bf81eae"
 
 def _twilio_client() -> TwilioSMSNotifier:
     return TwilioSMSNotifier(
-        json_config_path=_TEST_TWILIO_SMS_CONFIG_PATH)
+        json_config_path=_TEST_TWILIO_SMS_CONFIG_PATH,
+        game_id=_TEST_GAME_ID)
 
 
 class TwilioSMSTest(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ boto3
 twilio==6.5.0
 phonenumbers
 names
-
-
+sentry-sdk==0.14.3


### PR DESCRIPTION
Closes #130
-Uncomment the line in common.py/log_message to send messages to Sentry, however, be careful with this and avoid running too many tests with this on because we can easily go over the 5k events limit in Sentry. (We will probably need to add environment variables to control this and make sure it only runs in production. I haven't seen a way to do it in Sentry but it can be done with Python code).
-I haven't found a good way to test some of the code, particularly in game.py. It should be safe and error free, but the main concern is making sure that all of the game attributes possible are sent to log_message and that the data is in the right format.

Copy/pasting some info on the attributes in my email:

> Am I right in thinking that the logging function should be stateless? The reason that I'm asking is because a lot of attributes like game_id, player_id, phone_number, etc. are not available every time the logging function is called. They are only available in certain contexts. 
> 
> If we could save the state so that these attributes are saved the first time they are available, then it solves that problem, but from my understanding of the backend, the values would end up being incorrect and not accurately reflect the values of the user.
> 
> IF we can't save the state, many times the logging function would not have those values, and I'm not sure how much value logging those messages would bring, because we wouldn't be able to easily pair the logging message with the user who caused the message. Possibly we might be able to figure it out from location or browser, but only for a very small number of users.
> 
